### PR TITLE
Adds Install for Shipping Service Dependency

### DIFF
--- a/install_brews
+++ b/install_brews
@@ -17,6 +17,7 @@ if [ -x /usr/local/bin/brew ]; then
   brew install imagemagick
   brew install geoip
   brew install wget
+  brew install icu4c  # Required for charlock_holmes gem
 
 
   # casks (mac apps)


### PR DESCRIPTION
Adds install of icu4c library which is required by the charlock_holmes gem currently in use by the shipping service.